### PR TITLE
Move app dependencies to requirements.txt

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+requests

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,10 @@
-from setuptools import setup
 from distutils.core import setup
+
+
+with open('requirements.txt') as fobj:
+    install_requires = [line.strip() for line in fobj]
+
+
 setup(
       name='instantnews',
       version='1.2.4',
@@ -9,13 +14,9 @@ setup(
       url='https://github.com/shivam043/instantnews',
       license='MIT',
       py_modules=['instantnews'],
-      install_requires=[
-      'requests'
-      ],
+      install_requires=install_requires,
       entry_points='''
       [console_scripts]
       instantnews=instantnews:parser
       ''',
-      
 )
-      


### PR DESCRIPTION
Many developers expect a requirements.txt file to be present in a project in order to get a quick overview of the application's dependencies and to be able to do a light-weight install of an application for development via `pip install -r requirements.txt`.

Moving the dependencies out of setup.py also increases separation of concerns in the project and it's very simple to parse requirements.txt in setup.py, so really there's little downside to moving the dependencies into its own file.